### PR TITLE
feat: Go wasm - go 1.18 and generics

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -1,2 +1,2 @@
 mkdir -p .out
-GOOS=js GOARCH=wasm go build -o .out/contract.wasm main.go
+GOOS=js GOARCH=wasm go1.18rc1 build -o .out/contract.wasm main.go

--- a/go/common/imports/smartweave/imports.go
+++ b/go/common/imports/smartweave/imports.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ReadContractState(contractTxId string) js.Value {
-	promise := importSmartWeave().Call("readContractState", contractTxId).JSValue()
+	promise := importSmartWeave().Call("readContractState", contractTxId)
 	result, _ := common.Await(promise)
 
 	return result[0]

--- a/go/common/wasm.go
+++ b/go/common/wasm.go
@@ -1,13 +1,12 @@
-package wasm
+package common
 
 import (
 	"encoding/json"
 	"github.com/redstone-finance/redstone-contracts-wasm/go/common_types"
-	"github.com/redstone-finance/redstone-contracts-wasm/go/impl"
 	"syscall/js"
 )
 
-func Run(contract *impl.PstContract) {
+func Run[T any](contract common_types.SwContract[T]) {
 	// the Go way of defining WASM exports...
 	// standard "exports" from the wasm module do not work here...
 	// that's kinda ugly TBH
@@ -22,7 +21,7 @@ func Run(contract *impl.PstContract) {
 	<-make(chan bool)
 }
 
-func handle(contract *impl.PstContract) js.Func {
+func handle[T any](contract common_types.SwContract[T]) js.Func {
 	// note: each 'exported' function has to be wrapped into
 	// js.FuncOf(func(this js.Value, args []js.Value) interface{}
 	// - that's kinda ugly too...
@@ -80,14 +79,14 @@ func lang() interface{} {
 	})
 }
 
-func currentState(contract *impl.PstContract) interface{} {
+func currentState[T any](contract common_types.SwContract[T]) interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		data, _ := json.Marshal(contract.CurrentState())
 		return string(data)
 	})
 }
 
-func initState(contract *impl.PstContract) interface{} {
+func initState[T any](contract common_types.SwContract[T]) interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		contract.InitState(args[0].String())
 		return nil

--- a/go/common_types/types.go
+++ b/go/common_types/types.go
@@ -7,5 +7,9 @@ type Action struct {
 type ActionResult = interface{}
 
 //easyjson:skip
-type SwContract interface {
+type SwContract[S any] interface {
+	Handle(action Action, actionBytes []byte) (*S, ActionResult, error)
+	InitState(stateJson string)
+	UpdateState(newState *S)
+	CurrentState() S
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/redstone-finance/redstone-contracts-wasm/go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go/main.go
+++ b/go/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"github.com/redstone-finance/redstone-contracts-wasm/go/common"
+	"github.com/redstone-finance/redstone-contracts-wasm/go/common_types"
 	"github.com/redstone-finance/redstone-contracts-wasm/go/impl"
-	"github.com/redstone-finance/redstone-contracts-wasm/go/wasm"
+	"github.com/redstone-finance/redstone-contracts-wasm/go/types"
 )
 
 // the current state of the contract that contract developers have to define
@@ -10,5 +12,6 @@ var contract = impl.PstContract{}
 
 // handles all the WASM-JS related trickery...
 func main() {
-	wasm.Run(&contract)
+	var swContract common_types.SwContract[types.PstState] = &contract
+	common.Run(swContract)
 }


### PR DESCRIPTION
PoC. Requires Go 1.18 (currently in RC1, should be released in March).
generics are not currently supported by tinygo - https://github.com/tinygo-org/tinygo/issues/2158

Generics allow us to nicely split code into "common" and contract-specific modules. Not sure how to solve this without generics.

Tested on `go1.18rc1`